### PR TITLE
Removed pinned dependencies versions where not necessary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,14 +48,6 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.jenkins-ci.main</groupId>
-				<artifactId>jenkins-bom</artifactId>
-				<version>${jenkins.version}</version>
-				<scope>import</scope>
-				<type>pom</type>
-			</dependency>
-
-			<dependency>
 				<groupId>io.jenkins.tools.bom</groupId>
 				<artifactId>bom-2.401.x</artifactId>
 				<version>2745.vc7b_fe4c876fa_</version>
@@ -67,71 +59,18 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>parameterized-trigger</artifactId>
-			<version>2.43.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>envinject</artifactId>
-			<!-- 1.90 and earlier vulnerable: https://www.jenkins.io/security/advisory/2018-02-26/ -->
-			<version>2.901.v0038b_6471582</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>conditional-buildstep</artifactId>
-			<version>1.4.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>token-macro</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>mailer</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>maven-plugin</artifactId>
-			<!-- 3.3 and earlier vulnerable: https://www.jenkins.io/security/advisory/2019-07-31/ -->
-			<version>3.21</version>
 			<exclusions>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-lang3</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpclient</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore</artifactId>
-				</exclusion>
-                                <exclusion> <!-- TODO pending maven-plugin 3.0 -->
-                                    <groupId>org.apache.ant</groupId>
-                                    <artifactId>ant</artifactId>
-                                </exclusion>
-                                <exclusion> <!-- TODO pending maven-plugin 3.0 -->
-                                    <groupId>com.google.inject</groupId>
-                                    <artifactId>guice</artifactId>
-                                </exclusion>
 				<exclusion>
 					<groupId>javax.annotation</groupId>
 					<artifactId>javax.annotation-api</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>commons-net</groupId>
+					<artifactId>commons-net</artifactId>
+				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>copyartifact</artifactId>
-			<!-- 1.43.1 and earlier vulnerable: https://www.jenkins.io/security/advisory/2020-05-06/ -->
-			<version>686.v6fd37018d7c2</version>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
@@ -140,42 +79,35 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>matrix-project</artifactId>
-			<version>822.824.v14451b_c0fd42</version>
+			<artifactId>conditional-buildstep</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>copyartifact</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<!-- Workflow plugin imports are used to test compatibility -->
 		<dependency>
-			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-job</artifactId>
-			<scope>test</scope>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>envinject</artifactId>
+			<version>2.901.v0038b_6471582</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-cps</artifactId>
-			<scope>test</scope>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>junit</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-basic-steps</artifactId>
-			<scope>test</scope>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>matrix-project</artifactId>
+			<optional>true</optional>
 		</dependency>
-		<!--
-			this is here to resolve a RequireUpperBoundDeps failure
-			between maven-plugin (3.6) and jenkins-test-harness (3.8)
-		 -->
-		 <dependency>
-			<groupId>org.jenkins-ci.main</groupId>
-			<artifactId>jenkins-test-harness</artifactId>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-net</groupId>
-					<artifactId>commons-net</artifactId>
-				</exclusion>
-			</exclusions>
-		 </dependency>
-
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>parameterized-trigger</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>token-macro</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
POM dependencies got a bit bushy, so I pared them down:
- `jenkins-bom` is managed by `plugin`
- `mailer` dropped as I don't see it used anywhere
- `parameterized-trigger`, `conditional-buildstep`, `maven-plugin`, `copyartifact`, and `matrix-project` versions are managed in `io.jenkins.tools.bom`
- `workflow-job`, `workflow-cps`, and `workflow-basic-steps` test dependencies are managed in `io.jenkins.tools.bom`
- `commons-net` conflict resolved in `maven-plugin` instead of `jenkins-test-harness`
- removed unnecessary exclusions from `maven-plugin`
- sorted dependencies

### Testing done
Used a locally built version in our organization

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue